### PR TITLE
docs: Update lessons learned on Python overloading

### DIFF
--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -14,4 +14,4 @@
 - One can connect [Claude AI](https://claude.ai) to GitHub so it can browse your repository and collaborate with you.
 - A retro is very important in an async remote team collaboration
 - [Python overloading](https://stackoverflow.com/a/54423390/7260972) is just a type hint and doesn't really allow defining two separate overloads.
-  That requires usage of hack such as `isinstance()`, which makes overloads not attractive
+  That requires usage of hacks such as `isinstance()`, which makes overloads not attractive


### PR DESCRIPTION
Clarify that Python overloading is just a type hint and requires isinstance for separate overloads.