### PR TITLE
fix: use prek github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
-      - run: uv python install 3.13
-      - run: uv sync --group dev
-      - run: SKIP=no-commit-to-branch uv run prek run --all-files
-
+      - uses: j178/prek-action@v1
       # Create the XML report for Codecov
       - name: Generate coverage.xml
         run: uv run coverage xml


### PR DESCRIPTION
Follow-up to #148: reuse https://github.com/j178/prek-action instead of writing things by ourselves.