### PR TITLE
fix: dependabot PR title prefix v2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: chore
+      prefix-development: chore
+      include: scope


### PR DESCRIPTION
https://github.com/BayerC/open_cups/pull/133 seems to not have had the impact we wanted, see https://github.com/BayerC/open_cups/pull/150. This is a brute force approach following [this tutorial](https://dev.to/kengotoda/a-complete-guide-to-use-dependabot-with-semantic-release-and-vercel-ncc-for-github-actions-230p), since [the docs](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference) say

> [prefix](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#prefix)
>
>    Used for all commit messages unless prefix-development is also defined.

Let's see if this does the trick.