### PR TITLE
feat: use our own cookie for session ID storage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ dev = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.coverage.run]
+omit = ["src/open_cups/session_state.py"] # TODO (#165): Remove this omission if we stick with the cookies-based session state implementation
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/open_cups"]
 

--- a/src/open_cups/session_state.py
+++ b/src/open_cups/session_state.py
@@ -2,19 +2,32 @@ import uuid
 
 import streamlit as st
 
+COOKIE_NAME = "OPEN_CUPS_SESSION_ID"
+
 
 class SessionState:
     """Per-user session state wrapper.
 
-    See https://docs.streamlit.io/develop/api-reference/caching-and-state/st.session_state
-    for more details.
+    Uses a browser cookie to persist the session ID across page refreshes and
+    reconnects. This avoids leaking the session ID into the URL, which would
+    cause copy-pasted links to share the same identity.
+
+    See https://github.com/streamlit/streamlit/issues/10041 for the cookie
+    technique and https://github.com/BayerC/open_cups/issues/165 for context.
     """
 
     def __init__(self) -> None:
         if "session_id" not in st.session_state:
-            existing = st.query_params.get("session_id")
-            st.session_state.session_id = existing or str(uuid.uuid4())
-        st.query_params["session_id"] = st.session_state.session_id
+            session_id = st.context.cookies.get(COOKIE_NAME)
+            if session_id is None:
+                session_id = str(uuid.uuid4())
+                st.html(
+                    f"<script>document.cookie = "
+                    f'"{COOKIE_NAME}={session_id}; path=/; SameSite=Strict";'
+                    f"</script>",
+                    unsafe_allow_javascript=True,
+                )
+            st.session_state.session_id = session_id
 
     @property
     def session_id(self) -> str:

--- a/src/open_cups/session_state.py
+++ b/src/open_cups/session_state.py
@@ -1,6 +1,7 @@
 import uuid
 
 import streamlit as st
+from streamlit.components.v1 import html as components_html
 
 COOKIE_NAME = "OPEN_CUPS_SESSION_ID"
 
@@ -21,11 +22,11 @@ class SessionState:
             session_id = st.context.cookies.get(COOKIE_NAME)
             if session_id is None:
                 session_id = str(uuid.uuid4())
-                st.html(
-                    f"<script>document.cookie = "
+                components_html(
+                    "<script>document.cookie = "
                     f'"{COOKIE_NAME}={session_id}; path=/; SameSite=Strict";'
-                    f"</script>",
-                    unsafe_allow_javascript=True,
+                    "</script>",
+                    height=0,
                 )
             st.session_state.session_id = session_id
 


### PR DESCRIPTION
As proposed in https://github.com/BayerC/open_cups/issues/165#issuecomment-4297286437. Merge this to `main` for testing (or have @BayerC create a test deployment on streamlit).