### PR TITLE
revert: "feat: use our own cookie for session ID storage"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,6 @@ dev = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.coverage.run]
-omit = ["src/open_cups/session_state.py"] # TODO (#165): Remove this omission if we stick with the cookies-based session state implementation
-
 [tool.hatch.build.targets.wheel]
 packages = ["src/open_cups"]
 

--- a/src/open_cups/session_state.py
+++ b/src/open_cups/session_state.py
@@ -1,34 +1,20 @@
 import uuid
 
 import streamlit as st
-from streamlit.components.v1 import html as components_html
-
-COOKIE_NAME = "OPEN_CUPS_SESSION_ID"
 
 
 class SessionState:
     """Per-user session state wrapper.
 
-    Uses a browser cookie to persist the session ID across page refreshes and
-    reconnects. This avoids leaking the session ID into the URL, which would
-    cause copy-pasted links to share the same identity.
-
-    See https://github.com/streamlit/streamlit/issues/10041 for the cookie
-    technique and https://github.com/BayerC/open_cups/issues/165 for context.
+    See https://docs.streamlit.io/develop/api-reference/caching-and-state/st.session_state
+    for more details.
     """
 
     def __init__(self) -> None:
         if "session_id" not in st.session_state:
-            session_id = st.context.cookies.get(COOKIE_NAME)
-            if session_id is None:
-                session_id = str(uuid.uuid4())
-                components_html(
-                    "<script>document.cookie = "
-                    f'"{COOKIE_NAME}={session_id}; path=/; SameSite=Strict";'
-                    "</script>",
-                    height=0,
-                )
-            st.session_state.session_id = session_id
+            existing = st.query_params.get("session_id")
+            st.session_state.session_id = existing or str(uuid.uuid4())
+        st.query_params["session_id"] = st.session_state.session_id
 
     @property
     def session_id(self) -> str:


### PR DESCRIPTION
Reverts BayerC/open_cups#171

It's not working, I would prefer having a "working version" on main.

`st.query_params["session_id"] = st.session_state.session_id`

was kind of working, only the url copy was buggy